### PR TITLE
Uniform settings capitalization

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ const tabSections = [{
       value: 'false'
     }])
   }, {
-    label: 'Font color Style',
+    label: 'Font color style',
     path: 'desktop.iconview.fontColorStyle',
     type: 'select',
     defaultValue: 'system',


### PR DESCRIPTION
All the settings with the exception of `Font color Style` shared a sentence style of capitalization, so that label has been changed to match the others.